### PR TITLE
Fix null potentially being passed to strlen

### DIFF
--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -140,7 +140,7 @@ class Runner {
 			$parsed_args = preg_match_all( '#\([^\)]+\)#', $route, $matches );
 			$resource_id = ! empty( $matches[0] ) ? array_pop( $matches[0] ) : null;
 			$trimmed_route = rtrim( $route );
-			$is_singular = $resource_id === substr( $trimmed_route, - strlen( $resource_id ) );
+			$is_singular = $resource_id && $resource_id === substr( $trimmed_route, - strlen( $resource_id ) );
 
 			$command = '';
 			// List a collection


### PR DESCRIPTION
Fixes https://github.com/wp-cli/restful/issues/131

This could be fixed in a couple of ways:

1. Changing the right ternary from `null` to an empty string on 141
2. Using `??` (null coalescing) inside of `strlen` on 143
3. Falsey check on `$resource_id` on 143

This PR applies the third option because we felt it kept the intention of the original code, even though `$resource_id` is not used later.